### PR TITLE
*: add the summary result

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -10,7 +10,7 @@ import (
 type Benchmark interface {
 	Prepare() error
 	Run() error
-	Results() ([]*Result, error)
+	Results() ([]*Result, []*Result, error)
 }
 
 type Result struct {
@@ -37,9 +37,9 @@ func splitRecordChunks(records []*workload.Record, chunkSize int) []*workload.Re
 		end := i + chunkSize
 
 		if end > len(records) {
-			continue
+			end = len(records)
 		}
-
+		actualChunkSize := end - i
 		sumRecord := new(workload.Record)
 		for _, r := range records[i:end] {
 			sumRecord.Count += r.Count
@@ -52,8 +52,8 @@ func splitRecordChunks(records []*workload.Record, chunkSize int) []*workload.Re
 			}
 		}
 		sumRecord.Tag = records[i].Tag
-		sumRecord.Count /= float64(chunkSize)
-		sumRecord.AvgLatInMs /= float64(chunkSize)
+		sumRecord.Count /= float64(actualChunkSize)
+		sumRecord.AvgLatInMs /= float64(actualChunkSize)
 		res = append(res, sumRecord)
 	}
 	return res

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -37,9 +37,8 @@ func splitRecordChunks(records []*workload.Record, chunkSize int) []*workload.Re
 		end := i + chunkSize
 
 		if end > len(records) {
-			end = len(records)
+			continue
 		}
-		actualChunkSize := end - i
 		sumRecord := new(workload.Record)
 		for _, r := range records[i:end] {
 			sumRecord.Count += r.Count
@@ -52,8 +51,8 @@ func splitRecordChunks(records []*workload.Record, chunkSize int) []*workload.Re
 			}
 		}
 		sumRecord.Tag = records[i].Tag
-		sumRecord.Count /= float64(actualChunkSize)
-		sumRecord.AvgLatInMs /= float64(actualChunkSize)
+		sumRecord.Count /= float64(chunkSize)
+		sumRecord.AvgLatInMs /= float64(chunkSize)
 		res = append(res, sumRecord)
 	}
 	return res

--- a/bench/sysbench.go
+++ b/bench/sysbench.go
@@ -40,13 +40,13 @@ func (b *SysbenchBench) Run() error {
 	return nil
 }
 
-func (b *SysbenchBench) Results() ([]*Result, error) {
-	records, err := b.load.Records()
+func (b *SysbenchBench) Results() ([]*Result, []*Result, error) {
+	records, _, err := b.load.Records()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	results := EvalSysbenchRecords(records, b.intervalSecs, b.warmupSecs, b.cutTailSecs, 0, 0)
-	return results, nil
+	return results, nil, nil
 }
 
 func EvalSysbenchRecords(records []*workload.Record, intervalSecs int, warmupSecs int, cutTailSecs int, kNumber int, percent float64) []*Result {

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -60,7 +60,7 @@ func newLogCommand() *cobra.Command {
 			}
 			switch benchmark {
 			case "tpcc":
-				records, err = workload.ParseTpccRecords(logPath)
+				records, _, err = workload.ParseTpccRecords(logPath)
 				if err != nil {
 					return err
 				}
@@ -82,7 +82,7 @@ func newLogCommand() *cobra.Command {
 					}
 				}
 			case "sysbench":
-				records, err = workload.ParseSysbenchRecords(logPath)
+				records, _, err = workload.ParseSysbenchRecords(logPath)
 				if err != nil {
 					return err
 				}

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -41,9 +41,10 @@ var (
 )
 
 var (
-	benchId      int64
-	recordDbConn *sql.Conn
-	results      []*bench.Result
+	benchId        int64
+	recordDbConn   *sql.Conn
+	results        []*bench.Result
+	summaryResults []*bench.Result
 )
 
 func init() {
@@ -124,7 +125,8 @@ func maybeSaveTestResults() error {
 		}
 	}
 	if outputJson {
-		j, err := json.Marshal(results)
+		var totalResults = append(results, summaryResults...)
+		j, err := json.Marshal(totalResults)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -157,24 +159,24 @@ func newTpccCommand() *cobra.Command {
 			b := bench.NewTpccBench(load, intervalSecs, warmupSecs, cutTailSecs)
 			log.Info("Prepare benchmark...")
 			var err error
-			if len(brArgs) > 0 {
-				log.Info("Run BR restore...")
-				err = runBrRestore(brArgs)
-				if err != nil {
-					return errors.Trace(err)
-				}
-			} else {
-				err = b.Prepare()
-				if err != nil {
-					return errors.Trace(err)
-				}
-			}
+			//if len(brArgs) > 0 {
+			//	log.Info("Run BR restore...")
+			//	err = runBrRestore(brArgs)
+			//	if err != nil {
+			//		return errors.Trace(err)
+			//	}
+			//} else {
+			//	err = b.Prepare()
+			//	if err != nil {
+			//		return errors.Trace(err)
+			//	}
+			//}
 			log.Info("Start to run benchmark...")
 			err = b.Run()
 			if err != nil {
 				return errors.Trace(err)
 			}
-			results, err = b.Results()
+			results, summaryResults, err = b.Results()
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -232,7 +234,7 @@ func newSysbenchCommand() *cobra.Command {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			results, err = b.Results()
+			results, _, err = b.Results()
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -159,18 +159,18 @@ func newTpccCommand() *cobra.Command {
 			b := bench.NewTpccBench(load, intervalSecs, warmupSecs, cutTailSecs)
 			log.Info("Prepare benchmark...")
 			var err error
-			//if len(brArgs) > 0 {
-			//	log.Info("Run BR restore...")
-			//	err = runBrRestore(brArgs)
-			//	if err != nil {
-			//		return errors.Trace(err)
-			//	}
-			//} else {
-			//	err = b.Prepare()
-			//	if err != nil {
-			//		return errors.Trace(err)
-			//	}
-			//}
+			if len(brArgs) > 0 {
+				log.Info("Run BR restore...")
+				err = runBrRestore(brArgs)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			} else {
+				err = b.Prepare()
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
 			log.Info("Start to run benchmark...")
 			err = b.Run()
 			if err != nil {

--- a/workload/workload.go
+++ b/workload/workload.go
@@ -7,10 +7,12 @@ type Record struct {
 	AvgLatInMs float64
 	P95LatInMs float64
 	P99LatInMs float64
+	// TPM for TPCC
+	Payload interface{}
 }
 
 type Workload interface {
 	Prepare() error
 	Start() error
-	Records() ([]*Record, error)
+	Records() ([]*Record, []*Record, error)
 }


### PR DESCRIPTION
Signed-off-by: mahjonp <junpeng.man@gmail.com>

An output example of `bench tpcc --host 172.16.4.92 --port 33007 --warehouses 200 --time 1m --interval 10 --log test.log --br-args db --br-args --db=test --br-args --pd=10.0.2.80:2379 --br-args --storage=s3://mybucket/tpcc-200 --br-args --s3.endpoint=http://172.16.4.4:30812 --br-args --send-credentials-to-tikv=true --json`
```json
[
    {
        "type": "PAYMENT",
        "name": "tps",
        "value": "1.40"
    },
    {
        "type": "PAYMENT",
        "name": "tps-jitter-sd",
        "value": "13.04%"
    },
    {
        "type": "PAYMENT",
        "name": "tps-jitter-positive-max",
        "value": "14.29% in "
    },
    {
        "type": "PAYMENT",
        "name": "tps-jitter-negative-max",
        "value": "-14.29% in "
    },
    {
        "type": "PAYMENT",
        "name": "avg-lat",
        "value": "389.52ms"
    },
    {
        "type": "PAYMENT",
        "name": "avg-lat-jitter-sd",
        "value": "2.69%"
    },
    {
        "type": "PAYMENT",
        "name": "avg-lat-jitter-positive-max",
        "value": "2.58% in "
    },
    {
        "type": "PAYMENT",
        "name": "avg-lat-jitter-negative-max",
        "value": "-3.74% in "
    },
    {
        "type": "PAYMENT",
        "name": "p99-lat",
        "value": "457.18ms"
    },
    {
        "type": "PAYMENT",
        "name": "p99-lat-jitter-sd",
        "value": "4.61%"
    },
    {
        "type": "PAYMENT",
        "name": "p99-lat-jitter-positive-max",
        "value": "6.41% in "
    },
    {
        "type": "PAYMENT",
        "name": "p99-lat-jitter-negative-max",
        "value": "-4.59% in "
    },
    {
        "type": "NEW_ORDER",
        "name": "tps",
        "value": "1.00"
    },
    {
        "type": "NEW_ORDER",
        "name": "tps-jitter-sd",
        "value": "0.00%"
    },
    {
        "type": "NEW_ORDER",
        "name": "tps-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "NEW_ORDER",
        "name": "tps-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "NEW_ORDER",
        "name": "avg-lat",
        "value": "848.92ms"
    },
    {
        "type": "NEW_ORDER",
        "name": "avg-lat-jitter-sd",
        "value": "5.09%"
    },
    {
        "type": "NEW_ORDER",
        "name": "avg-lat-jitter-positive-max",
        "value": "5.14% in "
    },
    {
        "type": "NEW_ORDER",
        "name": "avg-lat-jitter-negative-max",
        "value": "-6.72% in "
    },
    {
        "type": "NEW_ORDER",
        "name": "p99-lat",
        "value": "1082.12ms"
    },
    {
        "type": "NEW_ORDER",
        "name": "p99-lat-jitter-sd",
        "value": "11.98%"
    },
    {
        "type": "NEW_ORDER",
        "name": "p99-lat-jitter-positive-max",
        "value": "17.83% in "
    },
    {
        "type": "NEW_ORDER",
        "name": "p99-lat-jitter-negative-max",
        "value": "-6.98% in "
    },
    {
        "type": "ORDER_STATUS",
        "name": "tps",
        "value": "1.00"
    },
    {
        "type": "ORDER_STATUS",
        "name": "tps-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "ORDER_STATUS",
        "name": "tps-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "ORDER_STATUS",
        "name": "tps-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "ORDER_STATUS",
        "name": "avg-lat",
        "value": "248.84ms"
    },
    {
        "type": "ORDER_STATUS",
        "name": "avg-lat-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "ORDER_STATUS",
        "name": "avg-lat-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "ORDER_STATUS",
        "name": "avg-lat-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "ORDER_STATUS",
        "name": "p99-lat",
        "value": "285.20ms"
    },
    {
        "type": "ORDER_STATUS",
        "name": "p99-lat-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "ORDER_STATUS",
        "name": "p99-lat-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "ORDER_STATUS",
        "name": "p99-lat-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "STOCK_LEVEL",
        "name": "tps",
        "value": "1.00"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "tps-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "tps-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "STOCK_LEVEL",
        "name": "tps-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "STOCK_LEVEL",
        "name": "avg-lat",
        "value": "620.80ms"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "avg-lat-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "avg-lat-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "STOCK_LEVEL",
        "name": "avg-lat-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "STOCK_LEVEL",
        "name": "p99-lat",
        "value": "637.50ms"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "p99-lat-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "p99-lat-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "STOCK_LEVEL",
        "name": "p99-lat-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "tps",
        "value": "1.00"
    },
    {
        "type": "DELIVERY",
        "name": "tps-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "DELIVERY",
        "name": "tps-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "tps-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "avg-lat",
        "value": "1128.87ms"
    },
    {
        "type": "DELIVERY",
        "name": "avg-lat-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "DELIVERY",
        "name": "avg-lat-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "avg-lat-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "p99-lat",
        "value": "1208.00ms"
    },
    {
        "type": "DELIVERY",
        "name": "p99-lat-jitter-sd",
        "value": "NaN%"
    },
    {
        "type": "DELIVERY",
        "name": "p99-lat-jitter-positive-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "p99-lat-jitter-negative-max",
        "value": "0.00% in "
    },
    {
        "type": "DELIVERY",
        "name": "tpm",
        "value": "9.40"
    },
    {
        "type": "NEW_ORDER",
        "name": "tpm",
        "value": "37.90"
    },
    {
        "type": "NEW_ORDER_ERR",
        "name": "tpm",
        "value": "1.10"
    },
    {
        "type": "ORDER_STATUS",
        "name": "tpm",
        "value": "10.00"
    },
    {
        "type": "PAYMENT",
        "name": "tpm",
        "value": "46.20"
    },
    {
        "type": "STOCK_LEVEL",
        "name": "tpm",
        "value": "1.10"
    }
]
```